### PR TITLE
Adding Slight Block Hardness

### DIFF
--- a/src/main/java/pl/asie/charset/wires/BlockWire.java
+++ b/src/main/java/pl/asie/charset/wires/BlockWire.java
@@ -39,6 +39,7 @@ public class BlockWire extends BlockContainer {
 		this.setBlockBounds(0, 0, 0, 1.0f, 0.125f, 1.0f);
 		this.setCreativeTab(ModCharsetLib.CREATIVE_TAB);
 		this.setUnlocalizedName("charset.wire");
+		this.setHardness(0.2F);
 	}
 
 	@Override


### PR DESCRIPTION
Noticed that when breaking a lot of wires, sometimes, due to their 0 hardness, there would be de-sync and I'd have to update the neighbor with redstone / relog to make it re-appear.