### PR TITLE
Fix DoubleDoor Tweak desync

### DIFF
--- a/src/main/java/pl/asie/charset/tweaks/TweakDoubleDoors.java
+++ b/src/main/java/pl/asie/charset/tweaks/TweakDoubleDoors.java
@@ -74,7 +74,7 @@ public class TweakDoubleDoors extends Tweak {
 
 	@SubscribeEvent(priority = EventPriority.LOW)
 	public void onPlayerInteract(PlayerInteractEvent event) {
-		if (event.action != PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK || event.entityPlayer.isSneaking()) {
+		if (event.action != PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK || event.entityPlayer.isSneaking() || event.world.isRemote) {
 			return;
 		}
 


### PR DESCRIPTION
Adds a !world.isRemote check to the Double Door tweak to prevent door desync if onItemUseFirst returns true.

The issue can be reproduced by right clicking a double door with the Chiseled Bit Bag from Chisels & Bits in your hand. The clicked door stays closed, the other door will open though, but only on the client, meaning you can't actually walk through.

Here's a GIF showing the issue as well: http://blay09.net/pics/DoubleDoor.gif