### PR TITLE
Transform IShifter interface to a capability

### DIFF
--- a/src/main/java/pl/asie/charset/pipes/ModCharsetPipes.java
+++ b/src/main/java/pl/asie/charset/pipes/ModCharsetPipes.java
@@ -1,13 +1,14 @@
 package pl.asie.charset.pipes;
 
-import java.util.Random;
-
+import mcmultipart.multipart.MultipartRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.SidedProxy;
@@ -15,10 +16,13 @@ import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
-
-import mcmultipart.multipart.MultipartRegistry;
+import pl.asie.charset.api.pipes.IShifter;
 import pl.asie.charset.lib.ModCharsetLib;
 import pl.asie.charset.lib.network.PacketRegistry;
+import pl.asie.charset.pipes.capability.ShifterImpl;
+import pl.asie.charset.pipes.capability.ShifterStorage;
+
+import java.util.Random;
 
 @Mod(modid = ModCharsetPipes.MODID, name = ModCharsetPipes.NAME, version = ModCharsetPipes.VERSION,
 		dependencies = ModCharsetLib.DEP_MCMP, updateJSON = ModCharsetLib.UPDATE_URL)
@@ -35,11 +39,16 @@ public class ModCharsetPipes {
 	@SidedProxy(clientSide = "pl.asie.charset.pipes.ProxyClient", serverSide = "pl.asie.charset.pipes.ProxyCommon")
 	public static ProxyCommon proxy;
 
+	@CapabilityInject(IShifter.class)
+	public static Capability<IShifter> CAP_SHIFTER;
+
 	public static Block shifterBlock;
 	public static Item itemPipe;
 
 	@EventHandler
 	public void preInit(FMLPreInitializationEvent event) {
+		CapabilityManager.INSTANCE.register(IShifter.class, new ShifterStorage(), ShifterImpl.class);
+
 		itemPipe = new ItemPipe();
 		GameRegistry.registerItem(itemPipe, "pipe");
 		MultipartRegistry.registerPart(PartPipe.class, "CharsetPipes:pipe");

--- a/src/main/java/pl/asie/charset/pipes/PartPipe.java
+++ b/src/main/java/pl/asie/charset/pipes/PartPipe.java
@@ -295,8 +295,8 @@ public class PartPipe extends Multipart implements IConnectable, ISlottedPart, I
 			return true;
 		} */
 
-		if (tile instanceof IShifter && ((IShifter) tile).getMode() == IShifter.Mode.Extract && ((IShifter) tile).getDirection() == side.getOpposite()) {
-			return true;
+		if (tile != null && tile.hasCapability(ModCharsetPipes.CAP_SHIFTER, side.getOpposite())) {
+			return tile.getCapability(ModCharsetPipes.CAP_SHIFTER, side.getOpposite()).getMode() == IShifter.Mode.Extract;
 		}
 
 		return false;
@@ -447,7 +447,8 @@ public class PartPipe extends Multipart implements IConnectable, ISlottedPart, I
 
 		tile = getWorld().getTileEntity(p);
 
-		if (tile instanceof IShifter && isMatchingShifter((IShifter) tile, dir, dist)) {
+		if (tile != null && tile.hasCapability(ModCharsetPipes.CAP_SHIFTER, dir)
+				&& isMatchingShifter(tile.getCapability(ModCharsetPipes.CAP_SHIFTER, dir), dir, dist)) {
 			shifterDistance[i] = dist;
 		} else {
 			shifterDistance[i] = 0;
@@ -493,8 +494,10 @@ public class PartPipe extends Multipart implements IConnectable, ISlottedPart, I
 				tile = getWorld().getTileEntity(getPos().offset(dir.getOpposite(), shifterDistance[dir.ordinal()]));
 		}
 
-		if (tile instanceof IShifter && isMatchingShifter((IShifter) tile, dir, Integer.MAX_VALUE)) {
-			return (IShifter) tile;
+		IShifter shifter;
+		if (tile.hasCapability(ModCharsetPipes.CAP_SHIFTER, dir) && isMatchingShifter(
+				shifter = tile.getCapability(ModCharsetPipes.CAP_SHIFTER, dir), dir, Integer.MAX_VALUE)) {
+			return shifter;
 		} else {
 			return null;
 		}

--- a/src/main/java/pl/asie/charset/pipes/PipeItem.java
+++ b/src/main/java/pl/asie/charset/pipes/PipeItem.java
@@ -143,7 +143,9 @@ public class PipeItem {
 						) {
 					TileEntity shifterTile = owner.getWorld().getTileEntity(owner.getPos().offset(output.getOpposite(), activeShifterDistance));
 
-					if (!(shifterTile instanceof IShifter) || !isShifterPushing((IShifter) shifterTile, output)) {
+					if (shifterTile == null
+							|| !shifterTile.hasCapability(ModCharsetPipes.CAP_SHIFTER, output)
+							|| !isShifterPushing(shifterTile.getCapability(ModCharsetPipes.CAP_SHIFTER, output), output)) {
 						needsRecalculation = true;
 					}
 				}

--- a/src/main/java/pl/asie/charset/pipes/TileShifter.java
+++ b/src/main/java/pl/asie/charset/pipes/TileShifter.java
@@ -11,6 +11,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ITickable;
 
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.items.IItemHandler;
 
 import pl.asie.charset.api.pipes.IShifter;
@@ -203,5 +204,19 @@ public class TileShifter extends TileBase implements IShifter, ITickable {
 				worldObj.notifyBlockOfStateChange(pos.offset(getDirection()), getBlockType());
 			}
 		}
+	}
+
+	@Override
+	public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
+		return ((facing == null || facing == getDirection()) && capability == ModCharsetPipes.CAP_SHIFTER)
+				|| super.hasCapability(capability, facing);
+	}
+
+	@Override
+	public <T> T getCapability(Capability<T> capability, EnumFacing facing) {
+		if ((facing == null || facing == getDirection()) && capability == ModCharsetPipes.CAP_SHIFTER) {
+			return (T) this;
+		}
+		return super.getCapability(capability, facing);
 	}
 }

--- a/src/main/java/pl/asie/charset/pipes/capability/ShifterImpl.java
+++ b/src/main/java/pl/asie/charset/pipes/capability/ShifterImpl.java
@@ -1,0 +1,88 @@
+package pl.asie.charset.pipes.capability;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
+import pl.asie.charset.api.pipes.IShifter;
+
+/**
+ * Default implementation for the shifter.
+ * @author rubensworks
+ */
+public class ShifterImpl implements IShifter {
+
+    private Mode mode;
+    private EnumFacing direction;
+    private int shiftDistance;
+    private boolean shifting;
+    private boolean hasFilter;
+    private ItemStack filter;
+
+    public ShifterImpl(Mode mode, EnumFacing direction, int shiftDistance, boolean isShifting,
+                       boolean hasFilter, ItemStack filter) {
+        this.mode = mode;
+        this.direction = direction;
+        this.shiftDistance = shiftDistance;
+        this.shifting = isShifting;
+        this.hasFilter = hasFilter;
+        this.filter = filter;
+    }
+
+    @Override
+    public Mode getMode() {
+        return mode;
+    }
+
+    @Override
+    public EnumFacing getDirection() {
+        return direction;
+    }
+
+    @Override
+    public int getShiftDistance() {
+        return shiftDistance;
+    }
+
+    @Override
+    public boolean isShifting() {
+        return shifting;
+    }
+
+    @Override
+    public boolean hasFilter() {
+        return hasFilter;
+    }
+
+    public ItemStack getFilter() {
+        return filter;
+    }
+
+    @Override
+    public boolean matches(ItemStack source) {
+        return ItemStack.areItemStacksEqual(filter, source);
+    }
+
+    public void setMode(Mode mode) {
+        this.mode = mode;
+    }
+
+    public void setDirection(EnumFacing direction) {
+        this.direction = direction;
+    }
+
+    public void setShiftDistance(int shiftDistance) {
+        this.shiftDistance = shiftDistance;
+    }
+
+    public void setShifting(boolean shifting) {
+        this.shifting = shifting;
+    }
+
+    public void setHasFilter(boolean hasFilter) {
+        this.hasFilter = hasFilter;
+    }
+
+    public void setFilter(ItemStack filter) {
+        this.filter = filter;
+    }
+
+}

--- a/src/main/java/pl/asie/charset/pipes/capability/ShifterStorage.java
+++ b/src/main/java/pl/asie/charset/pipes/capability/ShifterStorage.java
@@ -1,0 +1,44 @@
+package pl.asie.charset.pipes.capability;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.util.Constants;
+import pl.asie.charset.api.pipes.IShifter;
+
+/**
+ * Default storage implementation for the shifter capability.
+ * @author rubensworks
+ */
+public class ShifterStorage implements Capability.IStorage<IShifter> {
+    @Override
+    public NBTBase writeNBT(Capability<IShifter> capability, IShifter instance, EnumFacing side) {
+        NBTTagCompound tag = new NBTTagCompound();
+        tag.setBoolean("isExtract", instance.getMode() == IShifter.Mode.Extract);
+        tag.setInteger("direction", instance.getDirection().ordinal());
+        tag.setInteger("shiftDistance", instance.getShiftDistance());
+        tag.setBoolean("isShifting", instance.isShifting());
+        tag.setBoolean("hasFilter", instance.hasFilter());
+        ItemStack filter = ((ShifterImpl) instance).getFilter();
+        if(filter != null) {
+            tag.setTag("filter", filter.serializeNBT());
+        }
+        return tag;
+    }
+
+    @Override
+    public void readNBT(Capability<IShifter> capability, IShifter instance, EnumFacing side, NBTBase nbt) {
+        NBTTagCompound tag = (NBTTagCompound) nbt;
+        ShifterImpl shifter = (ShifterImpl) instance;
+        shifter.setMode(tag.getBoolean("isExtract") ? IShifter.Mode.Extract : IShifter.Mode.Shift);
+        shifter.setDirection(EnumFacing.VALUES[tag.getInteger("direction")]);
+        shifter.setShiftDistance(tag.getInteger("shiftDistance"));
+        shifter.setShifting(tag.getBoolean("isShifting"));
+        shifter.setHasFilter(tag.getBoolean("hasFilter"));
+        if(tag.hasKey("filter", Constants.NBT.TAG_COMPOUND)) {
+            shifter.setFilter(ItemStack.loadItemStackFromNBT(tag.getCompoundTag("filter")));
+        }
+    }
+}


### PR DESCRIPTION
This modifies shifter handling so that it is detected through a Forge capability.
This makes it more flexible for other mods to add shifting-features to other blocks.
This includes a default storage and shifter implementation which are currently unused and act just as an example.

Everything still seems to be working, but you may want to check yourself just to make sure I haven't missed anything.

I initially thought of removing the `IShifter#isShifting()` method and instead just add/remove the capability depending on its state. Not sure if this is the behaviour you want, so I excluded it for now.