### PR TITLE
Fix crash when not using item keepers.

### DIFF
--- a/src/main/java/pl/asie/charset/lib/handlers/PlayerDeathHandler.java
+++ b/src/main/java/pl/asie/charset/lib/handlers/PlayerDeathHandler.java
@@ -16,7 +16,6 @@ public class PlayerDeathHandler {
 	private Predicate<ItemStack> itemKeepPredicate;
 
 	public PlayerDeathHandler() {
-		MinecraftForge.EVENT_BUS.register(this);
 	}
 
 	public boolean hasPredicate() {


### PR DESCRIPTION
The death handler gets registered in postInit if it has a predicate,
this line only causes issues. This closes #61