### PR TITLE
Fix #119 - client crash when pipe contains blockless fluid

### DIFF
--- a/src/main/java/pl/asie/charset/lib/utils/DataSerializersCharset.java
+++ b/src/main/java/pl/asie/charset/lib/utils/DataSerializersCharset.java
@@ -42,7 +42,7 @@ public final class DataSerializersCharset {
         }
 
         @Override
-        public NBTTagCompound read(PacketBuffer buf) throws IOException {
+        public NBTTagCompound read(PacketBuffer buf) {
             return ByteBufUtils.readTag(buf);
         }
 

--- a/src/main/java/pl/asie/charset/pipes/pipe/SpecialRendererPipe.java
+++ b/src/main/java/pl/asie/charset/pipes/pipe/SpecialRendererPipe.java
@@ -190,7 +190,7 @@ public class SpecialRendererPipe extends MultipartSpecialRendererBase<PartPipe> 
 		if (entry.color == -1) {
 			return smodel;
 		} else {
-			return ModelTransformer.transform(smodel, entry.stack.getFluid().getBlock().getDefaultState(), 0L, new FluidColorTransformer(entry.color));
+			return ModelTransformer.transform(smodel, DEFAULT_STATE, 0L, new FluidColorTransformer(entry.color));
 		}
 	}
 
@@ -260,7 +260,7 @@ public class SpecialRendererPipe extends MultipartSpecialRendererBase<PartPipe> 
 						fluidModelCache.put(entry, model);
 					}
 
-					renderer.renderModelSmooth(world, model, entry.stack.getFluid().getBlock().getDefaultState(), pos, buffer, false, 0L);
+					renderer.renderModelSmooth(world, model, DEFAULT_STATE, pos, buffer, false, 0L);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes a client crash (#119) that occurs when a pipe is used to carry something like Immersive Engineering Creosote that can't be dumped out into the world with a bucket.

Also fixes a compile error. A fresh checkout didn't compile (error was something like can't override and add throws); maybe workspace wasn't fully cleaned after updating Forge/MCP version?