### PR TITLE
Fix containers being openable after destroyed

### DIFF
--- a/src/main/java/pl/asie/charset/lib/inventory/ContainerBase.java
+++ b/src/main/java/pl/asie/charset/lib/inventory/ContainerBase.java
@@ -24,6 +24,7 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import pl.asie.charset.lib.utils.ItemUtils;
 
 import java.util.ArrayList;
@@ -52,7 +53,8 @@ public abstract class ContainerBase extends Container {
 
 	@Override
 	public boolean canInteractWith(EntityPlayer player) {
-		return isOwnerPresent() && containerHandler != null ? containerHandler.isUsableByPlayer(player) : (owner == player);
+		return isOwnerPresent() && (containerHandler != null ? containerHandler.isUsableByPlayer(player) : (owner == player)) 
+			&& (containerHandler instanceof TileEntity ? ((TileEntity) listener).world.getTileEntity(((TileEntity) containerHandler).getPos()) == ((TileEntity) containerHandler) : true);
 	}
 
 	@Override

--- a/src/main/java/pl/asie/charset/lib/inventory/ContainerBase.java
+++ b/src/main/java/pl/asie/charset/lib/inventory/ContainerBase.java
@@ -54,7 +54,9 @@ public abstract class ContainerBase extends Container {
 	@Override
 	public boolean canInteractWith(EntityPlayer player) {
 		return isOwnerPresent() && (containerHandler != null ? containerHandler.isUsableByPlayer(player) : (owner == player)) 
-			&& (containerHandler instanceof TileEntity ? ((TileEntity) listener).world.getTileEntity(((TileEntity) containerHandler).getPos()) == ((TileEntity) containerHandler) : true);
+			&& (containerHandler instanceof TileEntity ? 
+			    	((TileEntity) containerHandler).world.getTileEntity(((TileEntity) containerHandler).getPos()) == ((TileEntity) containerHandler) 
+				: true);
 	}
 
 	@Override


### PR DESCRIPTION
Implements the fix stated on https://www.curseforge.com/minecraft/mc-mods/containerfix.

This PR fixes the fact that if you remain in a container's inventory after the container gets destroyed, you don't get booted out of the GUI by adding a check for if the tile entity at that location is still present.