### PR TITLE
Fix infinite logic mistakes in TileWaterBoiler

### DIFF
--- a/src/main/java/pl/asie/charset/module/power/steam/TileWaterBoiler.java
+++ b/src/main/java/pl/asie/charset/module/power/steam/TileWaterBoiler.java
@@ -141,7 +141,7 @@ public class TileWaterBoiler extends TileMirrorTargetBase implements ITickable {
 		if (waterTank.getFluidAmount() < 1000) {
 			BlockPos below = pos.down();
 			while (world.getTileEntity(below) instanceof TileWaterBoiler) {
-				below = pos.down();
+				below = below.down();
 			}
 			FluidStack desiredAmount = new FluidStack(FluidRegistry.WATER, 1000);
 
@@ -183,7 +183,7 @@ public class TileWaterBoiler extends TileMirrorTargetBase implements ITickable {
 
 		BlockPos ppos = pos.up();
 		while (world.getTileEntity(ppos) instanceof TileWaterBoiler) {
-			ppos = pos.up();
+			ppos = ppos.up();
 		}
 
 		toBoil *= CharsetPowerSteam.BOILER_OUTPUT_MULTIPLIER;


### PR DESCRIPTION
Hello o/ 
Was messing around with Charset in creative mode and stumbled upon infinite loop behavior in the boiler. With this resolved they should now be stackable as expected. 
Included is a screenshot of a world outside of dev where the behavior is functioning normally.

![A triple-stacked steam boiler on a floating stone platform.](https://github.com/user-attachments/assets/2d4bc9d4-29a4-4895-9451-57fdc974fd9d)
